### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I've had good sucess using Samsung PM991 NVMe SSDs.
 # Ordering
 
 The fabrication files inside `fab` are JLCPCB-ready. The board must be
-ordered with a 1.2mm board thickness to fit the miniPCIe slot.  
+ordered with a 1.0mm board thickness to fit the miniPCIe slot.  
 Additionally I'd highly recommend selecting the "controlled impedance"
 option with 7628 stackup. The PCIe interface has been routed with that
 stackup in mind.


### PR DESCRIPTION
Changed board thickness on line 30 from 1.2mm to 1.0mm - I ordered a batch with 1.2mm and found they do not fit, and a quick Google search indicates the miniPCIe spec is 1.0mm.